### PR TITLE
Use current version number in Readme (1.7.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,7 @@ Add `ex_cldr_calendars` to your `deps` in `mix.exs`.
 ```elixir
 def deps do
   [
-    {:ex_cldr_calendars, "~> 2.6"}
+    {:ex_cldr_calendars, "~> 1.7.1"}
     ...
   ]
 end


### PR DESCRIPTION
Fixes this error 

```
** (Mix) No matching version for ex_cldr_calendars ~> 2.6 (from: mix.exs) in registry                                            
                                                                                                                                 
The latest version is: 1.8.0-rc.0 
```