### PR TITLE
Fix version number in the installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add `ex_cldr_calendars` to your `deps` in `mix.exs`. **Note that `ex_cldr_calend
 ```elixir
 def deps do
   [
-    {:ex_cldr_calendars, "~> 1.23"}
+    {:ex_cldr_calendars, "~> 1.22"}
     ...
   ]
 end


### PR DESCRIPTION
There is no version 1.23, only 1.22.1 as the latest version